### PR TITLE
Find `"\\"` in `{entry_file}` and replace with `"/"`

### DIFF
--- a/bob-cli/dockerfiles/pyinstaller.Dockerfile
+++ b/bob-cli/dockerfiles/pyinstaller.Dockerfile
@@ -14,6 +14,9 @@ RUN WINEDEBUG=-all WINEPATH="Z:\\usr\\src\\win\\git\\cmd" wine ../win/python/pyt
 
 RUN mv ./dist ./_BOB_OUT/x86_64-pc-windows-msvc
 
+# For Linux, find "\\" in {entry_file} and replace with "/"
+RUN sed -i 's/\\\\/\//g' {entry_file}
+
 # Install deps for linux
 RUN UV_PYTHON="/usr/src/linux/python" ../linux/uv pip install pyinstaller --requirement requirements.txt
 # "Compile" for linux


### PR DESCRIPTION
Only for PyInstaller `.spec` files on Linux