### PR TITLE
Use `WORKDIR` instead of `RUN cd`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-package.version = "0.5.0"
+package.version = "0.5.2"
 package.edition = "2024"
 package.license-file = "LICENSE"
 members = ["bob-cli", "bob-lib"]

--- a/bob-cli/dockerfiles/csharp.Dockerfile
+++ b/bob-cli/dockerfiles/csharp.Dockerfile
@@ -13,7 +13,7 @@ RUN curl -L https://github.com/Jake-Shadle/xwin/releases/download/0.8.0/xwin-0.8
 WORKDIR "/usr/src"
 COPY . .
 
-RUN cd {base_dir}
+WORKDIR "/usr/src/{base_dir}"
 RUN dotnet publish -r linux-x64 -c Release -p:DebugType=None -p:DebugSymbols=false -p:PublishAot=true -o /usr/src/_BOB_OUT/x86_64-linux
 
 # PublishAotCrossXWin uses xwin to enable cross compilation


### PR DESCRIPTION
`cd {base_dir}` only changes the working directing for the current `RUN` and not subsequent ones. This caused build errors in projects that _actually_ relied on setting `base_dir`.